### PR TITLE
feat(m2a): PR2 - Evidence Layer Implementation

### DIFF
--- a/osiris/cli/logs.py
+++ b/osiris/cli/logs.py
@@ -1353,6 +1353,11 @@ def aiop_export(args: list) -> None:
         default="summary",
         help="Schema detail level (default: summary)",
     )
+    parser.add_argument(
+        "--logs-dir",
+        default=None,
+        help="Base logs directory (default: from config or 'logs')",
+    )
 
     try:
         parsed_args = parser.parse_args(args)
@@ -1360,17 +1365,11 @@ def aiop_export(args: list) -> None:
         console.print("❌ Invalid arguments. Use 'osiris logs aiop --help' for usage information.")
         return
 
-    # PR1 stub behavior
-    if parsed_args.last:
+    # PR2 stub implementation - parse flags and print placeholder message
+    if parsed_args.last or parsed_args.session:
         console.print("AIOP export not implemented yet (PR2).")
-        return  # Exit code 0
-    elif parsed_args.session:
-        if parsed_args.session.strip():  # Non-empty session ID
-            console.print("AIOP export not implemented yet (PR2).")
-            return  # Exit code 0
-        else:
-            console.print("Error: session id required")
-            sys.exit(2)
+        # Exit with code 0 as specified in milestone
+        return
     else:
         console.print("Error: Either --session or --last is required")
         sys.exit(2)

--- a/osiris/core/run_export_v2.py
+++ b/osiris/core/run_export_v2.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Osiris Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PR2 - Evidence Layer implementation for AIOP."""
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+
+
+def build_evidence_layer(
+    events: list[dict], metrics: list[dict], artifacts: list[Path], max_bytes: int = 300_000
+) -> dict:
+    """Compile evidence with stable IDs.
+
+    Args:
+        events: List of event dictionaries from events.jsonl
+        metrics: List of metric dictionaries from metrics.jsonl
+        artifacts: List of artifact paths
+        max_bytes: Maximum size in bytes for evidence layer
+
+    Returns:
+        Evidence layer dictionary with timeline, metrics, errors, and artifacts
+    """
+    # Build timeline from events
+    timeline = build_timeline(events, density="medium")
+
+    # Aggregate metrics
+    aggregated_metrics = aggregate_metrics(metrics, topk=100)
+
+    # Extract errors from events
+    errors = _extract_errors(events)
+
+    # Build artifact list
+    artifact_list = _build_artifact_list(artifacts)
+
+    evidence = {
+        "timeline": timeline,
+        "metrics": aggregated_metrics,
+        "errors": errors,
+        "artifacts": artifact_list,
+    }
+
+    # Apply truncation if needed
+    evidence, truncated = apply_truncation(evidence, max_bytes)
+
+    return evidence
+
+
+def generate_evidence_id(type: str, step_id: str, name: str, ts_ms: int) -> str:
+    """Generate canonical evidence ID: ev.<type>.<name>.<step_or_run>.<ts_ms>
+
+    Args:
+        type: Event type (will be sanitized)
+        step_id: Step identifier (will be sanitized) or None/empty for run-level
+        name: Event name (will be sanitized)
+        ts_ms: Timestamp in milliseconds since epoch
+
+    Returns:
+        Canonical evidence ID string
+    """
+    # Sanitize components - only [a-z0-9_]
+    type = _sanitize_id_component(type)
+    name = _sanitize_id_component(name)
+
+    # Use 'run' when step_id is missing or empty
+    step_or_run = _sanitize_id_component(step_id) if step_id else "run"
+
+    return f"ev.{type}.{name}.{step_or_run}.{ts_ms}"
+
+
+def build_timeline(events: list[dict], density: str = "medium") -> list[dict]:
+    """Build chronologically sorted timeline.
+
+    Args:
+        events: List of event dictionaries
+        density: Timeline density level (low/medium/high)
+
+    Returns:
+        Chronologically sorted list of timeline events with evidence IDs
+    """
+    timeline = []
+
+    for event in events:
+        # Extract key fields - support both 'type' and 'event' fields
+        event_type = event.get("type", "") or event.get("event", "")
+        if not event_type:  # Skip events without type
+            continue
+
+        step_id = event.get("step_id", "")
+        timestamp = event.get("ts", "")
+
+        # Use event type directly if already canonical, otherwise map it
+        if event_type in [
+            "START",
+            "STEP_START",
+            "METRICS",
+            "STEP_COMPLETE",
+            "COMPLETE",
+            "ERROR",
+            "DEBUG",
+            "TRACE",
+        ]:
+            canonical_type = event_type
+        else:
+            canonical_type = _get_canonical_event_type(event_type)
+
+        # Generate evidence ID
+        ts_ms = _timestamp_to_ms(timestamp)
+        evidence_id = generate_evidence_id("event", step_id, event_type.lower(), ts_ms)
+
+        timeline.append(
+            {
+                "@id": evidence_id,
+                "ts": timestamp,
+                "type": canonical_type,
+                "step_id": step_id if step_id else None,
+                "data": _sanitize_event_data(event),
+            }
+        )
+
+    # Sort chronologically
+    timeline.sort(key=lambda x: x["ts"])
+
+    # Apply density filter
+    if density == "low":
+        # Keep only major events
+        major_types = ["START", "COMPLETE", "STEP_START", "STEP_COMPLETE", "ERROR"]
+        timeline = [e for e in timeline if e["type"] in major_types]
+    elif density == "medium":
+        # low + METRICS
+        allowed_types = ["START", "COMPLETE", "STEP_START", "STEP_COMPLETE", "ERROR", "METRICS"]
+        timeline = [e for e in timeline if e["type"] in allowed_types]
+    # high density keeps all events
+
+    return timeline
+
+
+def aggregate_metrics(metrics: list[dict], topk: int = 100) -> dict:
+    """Aggregate and prioritize metrics.
+
+    Args:
+        metrics: List of metric dictionaries
+        topk: Maximum number of step metrics to return
+
+    Returns:
+        Dictionary with total_rows, total_duration_ms, and steps
+    """
+    # Track totals and per-step metrics
+    total_rows = 0
+    total_duration_ms = 0
+    step_metrics = {}
+
+    for metric in metrics:
+        step_id = metric.get("step_id", "")
+
+        # Handle direct field access (not nested under "metric")
+        rows_read = metric.get("rows_read", 0) if "rows_read" in metric else 0
+        rows_written = metric.get("rows_written", 0) if "rows_written" in metric else 0
+        rows_out = metric.get("rows_out", 0) if "rows_out" in metric else 0
+        duration_ms = metric.get("duration_ms", 0) if "duration_ms" in metric else 0
+
+        # Also handle nested under "metric" field for compatibility
+        name = metric.get("metric", "")
+        value = metric.get("value", 0)
+
+        if name == "rows_read":
+            rows_read = value
+        elif name == "rows_written":
+            rows_written = value
+        elif name == "rows_out":
+            rows_out = value
+        elif name == "duration_ms":
+            duration_ms = value
+
+        # Aggregate totals
+        if isinstance(rows_read, (int, float)) and rows_read > 0:
+            total_rows += rows_read
+        if isinstance(rows_written, (int, float)) and rows_written > 0:
+            total_rows += rows_written
+        if isinstance(rows_out, (int, float)) and rows_out > 0:
+            total_rows += rows_out
+        if isinstance(duration_ms, (int, float)) and duration_ms > 0:
+            total_duration_ms += duration_ms
+
+        # Aggregate per-step metrics
+        if step_id:
+            if step_id not in step_metrics:
+                step_metrics[step_id] = {
+                    "rows_read": None,
+                    "rows_written": None,
+                    "rows_out": None,
+                    "duration_ms": None,
+                }
+
+            # Update step metrics - sum if already present
+            if rows_read > 0:
+                if step_metrics[step_id]["rows_read"] is None:
+                    step_metrics[step_id]["rows_read"] = rows_read
+                else:
+                    step_metrics[step_id]["rows_read"] += rows_read
+            if rows_written > 0:
+                if step_metrics[step_id]["rows_written"] is None:
+                    step_metrics[step_id]["rows_written"] = rows_written
+                else:
+                    step_metrics[step_id]["rows_written"] += rows_written
+            if rows_out > 0:
+                if step_metrics[step_id]["rows_out"] is None:
+                    step_metrics[step_id]["rows_out"] = rows_out
+                else:
+                    step_metrics[step_id]["rows_out"] += rows_out
+            if duration_ms > 0:
+                if step_metrics[step_id]["duration_ms"] is None:
+                    step_metrics[step_id]["duration_ms"] = duration_ms
+                else:
+                    step_metrics[step_id]["duration_ms"] += duration_ms
+
+    # Sort steps by duration desc, then rows desc, then step_id asc
+    sorted_steps = sorted(
+        step_metrics.items(),
+        key=lambda x: (
+            -(x[1]["duration_ms"] or 0),
+            -((x[1]["rows_read"] or 0) + (x[1]["rows_written"] or 0) + (x[1]["rows_out"] or 0)),
+            x[0],
+        ),
+    )
+
+    # Apply topk limit to steps
+    limited_steps = dict(sorted_steps[:topk])
+
+    return {
+        "total_rows": total_rows if total_rows > 0 else 0,
+        "total_duration_ms": total_duration_ms if total_duration_ms > 0 else 0,
+        "steps": limited_steps,
+    }
+
+
+def canonicalize_json(data: dict) -> str:
+    """Produce deterministic JSON with sorted keys.
+
+    Args:
+        data: Dictionary to serialize
+
+    Returns:
+        Deterministic JSON string with sorted keys
+    """
+    return json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False, separators=(",", ": "))
+
+
+def apply_truncation(data: dict, max_bytes: int) -> tuple[dict, bool]:
+    """Truncate with object-level markers if exceeds size limit.
+
+    Args:
+        data: Data dictionary to truncate
+        max_bytes: Maximum size in bytes
+
+    Returns:
+        Tuple of (truncated_data, was_truncated)
+    """
+    json_str = json.dumps(data)
+    current_size = len(json_str.encode("utf-8"))
+
+    if current_size <= max_bytes:
+        return data, False
+
+    was_truncated = False
+
+    # Truncate timeline first (usually largest)
+    if "timeline" in data and len(data["timeline"]) > 200:
+        # Keep first 100 and last 100
+        original_count = len(data["timeline"])
+        data["timeline"] = data["timeline"][:100] + data["timeline"][-100:]
+
+        # Add truncation markers to timeline
+        data["timeline"] = {
+            "items": data["timeline"],
+            "truncated": True,
+            "dropped_events": original_count - 200,
+            "annex_ref": None,
+        }
+        was_truncated = True
+
+    # Check size again
+    json_str = json.dumps(data)
+    current_size = len(json_str.encode("utf-8"))
+
+    # Truncate metrics if still too large
+    if (
+        current_size > max_bytes
+        and "metrics" in data
+        and "steps" in data["metrics"]
+        and len(data["metrics"]["steps"]) > 20
+    ):
+        original_step_count = len(data["metrics"]["steps"])
+        # Keep only first 20 steps (already sorted by priority)
+        step_items = list(data["metrics"]["steps"].items())[:20]
+        data["metrics"]["steps"] = dict(step_items)
+
+        # Add truncation markers to metrics
+        data["metrics"]["truncated"] = True
+        data["metrics"]["dropped_series"] = original_step_count - 20
+        was_truncated = True
+
+    # Add optional summary flag
+    if was_truncated:
+        data["truncated"] = True
+
+    return data, was_truncated
+
+
+# Internal helper functions (not part of PR2 public API)
+
+
+def _sanitize_id_component(text: str) -> str:
+    """Sanitize text for use in evidence IDs.
+
+    Converts to lowercase and replaces non-alphanumeric with underscore.
+    Only allows [a-z0-9_]. Collapses multiple underscores.
+    """
+    # Convert to lowercase and replace anything not a-z0-9 with underscore
+    sanitized = re.sub(r"[^a-z0-9]+", "_", text.lower())
+    # Remove leading/trailing underscores
+    sanitized = sanitized.strip("_")
+    return sanitized if sanitized else "unknown"
+
+
+def _timestamp_to_ms(timestamp: str) -> int:
+    """Convert ISO timestamp to milliseconds since epoch."""
+    try:
+        # Handle both with and without timezone
+        if "Z" in timestamp:
+            dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        elif "+" in timestamp or timestamp.count("-") > 2:
+            dt = datetime.fromisoformat(timestamp)
+        else:
+            # Assume UTC if no timezone
+            dt = datetime.fromisoformat(timestamp + "+00:00")
+        return int(dt.timestamp() * 1000)
+    except (ValueError, AttributeError, TypeError):
+        return 0
+
+
+def _sanitize_event_data(event: dict) -> dict:
+    """Remove sensitive and redundant fields from event data."""
+    sensitive_fields = ["password", "token", "key", "secret", "credential"]
+    redundant_fields = ["ts", "session", "event"]
+
+    sanitized = {}
+    for key, value in event.items():
+        # Skip sensitive fields
+        if any(s in key.lower() for s in sensitive_fields):
+            continue
+        # Skip redundant fields
+        if key in redundant_fields:
+            continue
+        sanitized[key] = value
+
+    return sanitized
+
+
+def _extract_errors(events: list[dict]) -> list[dict]:
+    """Extract error events from event list."""
+    errors = []
+
+    for event in events:
+        if "error" in event.get("event", "").lower() or event.get("level") == "ERROR":
+            ts_ms = _timestamp_to_ms(event.get("ts", ""))
+            step_id = event.get("step_id", "")
+            evidence_id = generate_evidence_id("event", step_id, "error", ts_ms)
+
+            errors.append(
+                {
+                    "@id": evidence_id,
+                    "step_id": step_id if step_id else None,
+                    "message": event.get("error", event.get("msg", "Unknown error")),
+                    "severity": "error",
+                    "ts": event.get("ts", ""),
+                }
+            )
+
+    return errors
+
+
+def _build_artifact_list(artifacts: list[Path]) -> list[dict]:
+    """Build list of artifact metadata."""
+    import hashlib
+
+    artifact_list = []
+
+    for artifact_path in artifacts:
+        if artifact_path.exists() and artifact_path.is_file():
+            # Calculate content hash
+            sha256_hash = hashlib.sha256()
+            with open(artifact_path, "rb") as f:
+                for byte_block in iter(lambda: f.read(4096), b""):
+                    sha256_hash.update(byte_block)
+
+            artifact_list.append(
+                {
+                    "@id": f"artifact.{artifact_path.stem}.{sha256_hash.hexdigest()[:8]}",
+                    "path": str(artifact_path),
+                    "size_bytes": artifact_path.stat().st_size,
+                    "content_hash": f"sha256:{sha256_hash.hexdigest()}",
+                }
+            )
+
+    return artifact_list
+
+
+def _get_canonical_event_type(event_type: str) -> str:
+    """Map event types to canonical types."""
+    event_lower = event_type.lower()
+
+    if "start" in event_lower:
+        if "step" in event_lower:
+            return "STEP_START"
+        return "START"
+    elif "complete" in event_lower or "end" in event_lower:
+        if "step" in event_lower:
+            return "STEP_COMPLETE"
+        return "COMPLETE"
+    elif "error" in event_lower:
+        return "ERROR"
+    elif "metric" in event_lower:
+        return "METRICS"
+    elif "debug" in event_lower:
+        return "DEBUG"
+    elif "trace" in event_lower:
+        return "TRACE"
+    else:
+        # Default mapping for known types
+        return event_type.upper()

--- a/tests/cli/test_logs_aiop.py
+++ b/tests/cli/test_logs_aiop.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for osiris logs aiop command (PR1 stub)."""
+"""Tests for osiris logs aiop command (PR2 implementation)."""
 
 from unittest.mock import patch
 
@@ -40,25 +40,26 @@ def test_aiop_help():
 
 
 def test_aiop_last_flag():
-    """Test that --last returns stub message with exit code 0."""
+    """Test that --last prints stub message for PR2."""
     from osiris.cli.logs import aiop_export
 
     with patch("osiris.cli.logs.console") as mock_console:
-        # Should not raise SystemExit since we return normally
+        # Test with --last
         aiop_export(["--last"])
 
-        # Verify stub message
+        # Verify stub message was printed
         mock_console.print.assert_called_with("AIOP export not implemented yet (PR2).")
 
 
 def test_aiop_session_with_id():
-    """Test that --session with valid ID returns stub message."""
+    """Test that --session with valid ID prints stub message for PR2."""
     from osiris.cli.logs import aiop_export
 
     with patch("osiris.cli.logs.console") as mock_console:
+        # Test with specific session
         aiop_export(["--session", "run_123456"])
 
-        # Verify stub message
+        # Verify stub message was printed
         mock_console.print.assert_called_with("AIOP export not implemented yet (PR2).")
 
 
@@ -98,7 +99,7 @@ def test_aiop_missing_required():
 
 
 def test_aiop_parse_all_flags():
-    """Test that all flags are parsed correctly."""
+    """Test that all flags are parsed correctly in stub."""
     from osiris.cli.logs import aiop_export
 
     with patch("osiris.cli.logs.console") as mock_console:
@@ -125,7 +126,7 @@ def test_aiop_parse_all_flags():
             ]
         )
 
-        # Should still print stub message
+        # Verify stub message printed (flags parsed but nothing done)
         mock_console.print.assert_called_with("AIOP export not implemented yet (PR2).")
 
 
@@ -139,7 +140,7 @@ def test_aiop_invalid_format():
 
         # Check for error message
         calls = str(mock_console.print.call_args_list)
-        assert "Invalid arguments" in calls
+        assert "Invalid arguments" in calls or "invalid choice" in calls.lower()
 
 
 def test_aiop_invalid_policy():
@@ -152,7 +153,7 @@ def test_aiop_invalid_policy():
 
         # Check for error message
         calls = str(mock_console.print.call_args_list)
-        assert "Invalid arguments" in calls
+        assert "Invalid arguments" in calls or "invalid choice" in calls.lower()
 
 
 def test_aiop_invalid_timeline_density():
@@ -165,7 +166,7 @@ def test_aiop_invalid_timeline_density():
 
         # Check for error message
         calls = str(mock_console.print.call_args_list)
-        assert "Invalid arguments" in calls
+        assert "Invalid arguments" in calls or "invalid choice" in calls.lower()
 
 
 def test_aiop_invalid_schema_mode():
@@ -178,4 +179,4 @@ def test_aiop_invalid_schema_mode():
 
         # Check for error message
         calls = str(mock_console.print.call_args_list)
-        assert "Invalid arguments" in calls
+        assert "Invalid arguments" in calls or "invalid choice" in calls.lower()

--- a/tests/core/test_run_export_v2.py
+++ b/tests/core/test_run_export_v2.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Osiris Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for run_export_v2 (PR2 - Evidence Layer functions only)."""
+
+import json
+import tempfile
+from pathlib import Path
+
+
+class TestRunExportV2:
+    """Test PR2 Evidence Layer functions."""
+
+    def test_evidence_id_generation(self):
+        """Test evidence ID generation follows correct format."""
+        from osiris.core.run_export_v2 import generate_evidence_id
+
+        # Test ID generation with step
+        evidence_id = generate_evidence_id("event", "step_1", "complete", 1234567890)
+
+        assert evidence_id == "ev.event.complete.step_1.1234567890"
+
+        # Test run-level event (no step_id)
+        evidence_id = generate_evidence_id("event", "", "start", 1234567890)
+
+        assert evidence_id == "ev.event.start.run.1234567890"
+
+        # Test sanitization
+        evidence_id = generate_evidence_id("Error-Type", "Step-123", "Failed!", 1234567890)
+
+        assert evidence_id == "ev.error_type.failed.step_123.1234567890"
+
+    def test_timeline_chronological_ordering(self):
+        """Test timeline events are sorted chronologically."""
+        from osiris.core.run_export_v2 import build_timeline
+
+        # Create unordered events
+        events = [
+            {"event": "step_complete", "step_id": "step_3", "ts": "2024-01-15T10:03:00Z"},
+            {"event": "step_start", "step_id": "step_1", "ts": "2024-01-15T10:01:00Z"},
+            {"event": "step_complete", "step_id": "step_2", "ts": "2024-01-15T10:02:00Z"},
+        ]
+
+        timeline = build_timeline(events, "high")
+
+        # Verify chronological order and structure
+        assert len(timeline) == 3
+        assert timeline[0]["type"] == "STEP_START"
+        assert timeline[0]["step_id"] == "step_1"
+        assert timeline[1]["type"] == "STEP_COMPLETE"
+        assert timeline[2]["type"] == "STEP_COMPLETE"
+
+        # Verify @id format
+        assert timeline[0]["@id"].startswith("ev.event.step_start.step_1.")
+        assert "@id" in timeline[0]
+        assert "ts" in timeline[0]
+
+    def test_metrics_aggregation_and_topk(self):
+        """Test metrics aggregation returns correct shape."""
+        from osiris.core.run_export_v2 import aggregate_metrics
+
+        # Create metrics
+        metrics = [
+            {"metric": "rows_read", "step_id": "extract", "value": 100},
+            {"metric": "rows_read", "step_id": "extract", "value": 200},  # Should be summed
+            {"metric": "rows_written", "step_id": "load", "value": 250},
+            {"metric": "duration_ms", "step_id": "extract", "value": 1500},
+            {"metric": "duration_ms", "step_id": "load", "value": 500},
+        ]
+
+        aggregated = aggregate_metrics(metrics, topk=3)
+
+        # Verify structure
+        assert "total_rows" in aggregated
+        assert "total_duration_ms" in aggregated
+        assert "steps" in aggregated
+
+        # Verify totals
+        assert aggregated["total_rows"] == 550  # 300 read + 250 written
+        assert aggregated["total_duration_ms"] == 2000  # 1500 + 500
+
+        # Verify steps structure
+        assert "extract" in aggregated["steps"]
+        assert aggregated["steps"]["extract"]["rows_read"] == 300
+        assert aggregated["steps"]["extract"]["duration_ms"] == 1500
+        assert "load" in aggregated["steps"]
+        assert aggregated["steps"]["load"]["rows_written"] == 250
+
+    def test_deterministic_json_canonicalization(self):
+        """Test JSON output is deterministic."""
+        from osiris.core.run_export_v2 import canonicalize_json
+
+        # Create data with unsorted keys
+        data = {
+            "z_field": "last",
+            "a_field": "first",
+            "m_field": "middle",
+            "nested": {"z": 1, "a": 2},
+        }
+
+        json_str1 = canonicalize_json(data)
+        json_str2 = canonicalize_json(data)
+
+        # Verify deterministic output
+        assert json_str1 == json_str2
+
+        # Verify keys are sorted
+        parsed = json.loads(json_str1)
+        keys = list(parsed.keys())
+        assert keys == ["a_field", "m_field", "nested", "z_field"]
+
+    def test_truncation_with_markers(self):
+        """Test truncation applies object-level markers."""
+        from osiris.core.run_export_v2 import apply_truncation
+
+        # Create large data structure
+        data = {
+            "timeline": [
+                {"@id": f"ev.event.test.run.{i}", "type": "DEBUG", "data": "x" * 100}
+                for i in range(300)
+            ],
+            "metrics": {
+                "total_rows": 1000,
+                "total_duration_ms": 5000,
+                "steps": {f"step_{i}": {"rows_read": i * 10} for i in range(50)},
+            },
+        }
+
+        # Apply truncation with small limit
+        truncated_data, was_truncated = apply_truncation(data, max_bytes=10000)
+
+        assert was_truncated is True
+        assert "truncated" in truncated_data  # Global flag
+
+        # Check timeline truncation markers
+        if isinstance(truncated_data["timeline"], dict):
+            assert truncated_data["timeline"]["truncated"] is True
+            assert "dropped_events" in truncated_data["timeline"]
+            assert truncated_data["timeline"]["dropped_events"] == 100  # 300 - 200
+            assert truncated_data["timeline"]["annex_ref"] is None
+
+        # Check metrics truncation markers if applied
+        if "truncated" in truncated_data["metrics"]:
+            assert "dropped_series" in truncated_data["metrics"]
+
+    def test_error_extraction(self):
+        """Test error events are properly extracted from evidence layer."""
+        from osiris.core.run_export_v2 import build_evidence_layer
+
+        events = [
+            {"event": "step_complete", "ts": "2024-01-15T10:01:00Z"},
+            {"event": "error", "ts": "2024-01-15T10:02:00Z", "error": "Connection failed"},
+            {
+                "event": "step_error",
+                "step_id": "extract",
+                "ts": "2024-01-15T10:03:00Z",
+                "msg": "Timeout",
+            },
+            {"level": "ERROR", "ts": "2024-01-15T10:04:00Z", "msg": "Critical error"},
+        ]
+
+        evidence = build_evidence_layer(events, [], [])
+        errors = evidence["errors"]
+
+        assert len(errors) == 3
+        assert errors[0]["message"] == "Connection failed"
+        assert errors[1]["message"] == "Timeout"
+        assert errors[2]["message"] == "Critical error"
+
+        # Check @id format
+        assert all("@id" in error for error in errors)
+        assert errors[0]["@id"].startswith("ev.event.error.")
+
+    def test_artifact_listing(self):
+        """Test artifact listing in evidence layer."""
+        from osiris.core.run_export_v2 import build_evidence_layer
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            artifacts_dir = Path(tmp_dir) / "artifacts"
+            artifacts_dir.mkdir(parents=True)
+
+            # Create sample artifacts
+            output_csv = artifacts_dir / "output.csv"
+            report_pdf = artifacts_dir / "report.pdf"
+            output_csv.write_text("data")
+            report_pdf.write_bytes(b"binary")
+
+            # Build evidence layer with artifacts
+            evidence = build_evidence_layer([], [], [output_csv, report_pdf])
+            artifacts = evidence["artifacts"]
+
+            assert len(artifacts) == 2
+
+            # Check structure
+            csv_artifact = next(a for a in artifacts if "output.csv" in a["path"])
+            assert "@id" in csv_artifact
+            assert "content_hash" in csv_artifact
+            assert csv_artifact["content_hash"].startswith("sha256:")
+            assert csv_artifact["size_bytes"] == 4  # "data" is 4 bytes
+
+    def test_timeline_density_filtering(self):
+        """Test timeline density affects event filtering."""
+        from osiris.core.run_export_v2 import build_timeline
+
+        # Create events with various types
+        events = [
+            {"event": "run_start", "ts": "2024-01-15T10:00:00Z"},
+            {"event": "debug", "ts": "2024-01-15T10:01:00Z"},
+            {"event": "step_complete", "step_id": "extract", "ts": "2024-01-15T10:02:00Z"},
+            {"event": "trace", "ts": "2024-01-15T10:03:00Z"},
+            {"event": "error", "ts": "2024-01-15T10:04:00Z"},
+            {"event": "run_complete", "ts": "2024-01-15T10:05:00Z"},
+        ]
+
+        # Low density - only major events
+        timeline_low = build_timeline(events, "low")
+        assert len(timeline_low) == 4  # START, STEP_COMPLETE, ERROR, COMPLETE
+        assert all(
+            e["type"] in ["START", "STEP_COMPLETE", "ERROR", "COMPLETE"] for e in timeline_low
+        )
+
+        # Medium density - filter verbose
+        timeline_medium = build_timeline(events, "medium")
+        assert len(timeline_medium) == 4  # No DEBUG/TRACE
+        assert all(e["type"] not in ["DEBUG", "TRACE"] for e in timeline_medium)
+
+        # High density - all events
+        timeline_high = build_timeline(events, "high")
+        assert len(timeline_high) == 6  # All events
+
+        # Verify no unknown types
+        for timeline in [timeline_low, timeline_medium, timeline_high]:
+            assert all("unknown" not in e["@id"] for e in timeline)
+
+    def test_evidence_layer_structure(self):
+        """Test evidence layer returns correct keys."""
+        from osiris.core.run_export_v2 import build_evidence_layer
+
+        events = [
+            {"event": "run_start", "ts": "2024-01-15T10:00:00Z"},
+            {"event": "step_complete", "step_id": "extract", "ts": "2024-01-15T10:01:00Z"},
+        ]
+        metrics = [
+            {"metric": "rows_read", "step_id": "extract", "value": 100},
+        ]
+
+        evidence = build_evidence_layer(events, metrics, [])
+
+        # Verify top-level keys
+        assert "timeline" in evidence  # NOT "events"
+        assert "metrics" in evidence
+        assert "artifacts" in evidence
+        assert "errors" in evidence
+
+        # Verify timeline structure
+        assert isinstance(evidence["timeline"], list)
+        assert len(evidence["timeline"]) > 0
+        assert all("@id" in item for item in evidence["timeline"])
+        assert all(item["@id"].startswith("ev.event.") for item in evidence["timeline"])
+
+        # Verify metrics has steps key
+        assert "steps" in evidence["metrics"]
+
+    def test_timeline_density_and_typing_exact(self):
+        """Test A: Timeline density & typing with exact input."""
+        from osiris.core.run_export_v2 import build_timeline
+
+        # Exact input from reviewer
+        events = [
+            {
+                "ts": "2024-01-15T10:00:05Z",
+                "type": "METRICS",
+                "step_id": "extract",
+                "metrics": {"rows_read": 1000},
+            },
+            {"ts": "2024-01-15T10:00:01Z", "type": "STEP_START", "step_id": "extract"},
+            {"ts": "2024-01-15T10:00:06Z", "type": "STEP_COMPLETE", "step_id": "extract"},
+            {"ts": "2024-01-15T10:00:00Z", "type": "START", "session": "run_123"},
+            {"ts": "2024-01-15T10:05:00Z", "type": "COMPLETE", "total_rows": 1000},
+        ]
+
+        # Low density test
+        timeline_low = build_timeline(events, "low")
+        low_types = [e["type"] for e in timeline_low]
+        assert low_types == ["START", "STEP_START", "STEP_COMPLETE", "COMPLETE"]
+
+        # Medium density test
+        timeline_medium = build_timeline(events, "medium")
+        medium_types = [e["type"] for e in timeline_medium]
+        assert medium_types == ["START", "STEP_START", "METRICS", "STEP_COMPLETE", "COMPLETE"]
+
+        # High density test
+        timeline_high = build_timeline(events, "high")
+        high_types = [e["type"] for e in timeline_high]
+        assert high_types == ["START", "STEP_START", "METRICS", "STEP_COMPLETE", "COMPLETE"]
+
+        # No unknown types
+        for timeline in [timeline_low, timeline_medium, timeline_high]:
+            assert all("unknown" not in e["type"].lower() for e in timeline)
+
+    def test_metrics_aggregation_and_totals_exact(self):
+        """Test B: Metrics aggregation & totals with exact input."""
+        from osiris.core.run_export_v2 import aggregate_metrics
+
+        # Exact input from reviewer
+        metrics = [
+            {"step_id": "extract", "rows_read": 10234, "duration_ms": 5000},
+            {"step_id": "transform", "rows_out": 10234, "duration_ms": 180000},
+            {"step_id": "export", "rows_written": 10234, "duration_ms": 120000},
+        ]
+
+        # Test topk=2
+        result_2 = aggregate_metrics(metrics, topk=2)
+        assert "steps" in result_2
+        assert len(result_2["steps"]) == 2  # Exactly 2 steps
+
+        # Test topk=3
+        result_3 = aggregate_metrics(metrics, topk=3)
+        assert result_3["total_rows"] is not None
+        assert result_3["total_rows"] == 30702  # 10234 * 3
+        assert result_3["total_duration_ms"] is not None
+        assert result_3["total_duration_ms"] == 305000  # 5000 + 180000 + 120000
+
+    def test_truncation_markers_exact(self):
+        """Test C: Truncation markers with exact input."""
+
+        from osiris.core.run_export_v2 import apply_truncation
+
+        # Exact input from reviewer
+        big = {
+            "timeline": [
+                {"ts": f"2024-01-01T00:00:{i:02d}Z", "type": "DEBUG", "i": i} for i in range(50000)
+            ],
+            "metrics": {"series": [{"k": i} for i in range(50000)]},
+        }
+
+        cropped, did = apply_truncation(big, max_bytes=100_000)
+
+        # Assertions
+        assert did is True
+
+        # Check object-level markers
+
+        # Timeline markers
+        if isinstance(cropped.get("timeline"), dict):
+            assert cropped["timeline"]["truncated"] is True
+            assert "dropped_events" in cropped["timeline"]
+
+        # Metrics markers (if truncated)
+        if "truncated" in cropped.get("metrics", {}):
+            assert cropped["metrics"]["truncated"] is True
+            assert "dropped_series" in cropped["metrics"]
+
+    def test_evidence_layer_shape_exact(self):
+        """Test D: Evidence layer shape with exact input."""
+        from osiris.core.run_export_v2 import build_evidence_layer
+
+        # Exact input from reviewer
+        events = [
+            {"ts": "2024-01-15T10:00:00Z", "type": "START", "session": "run_123"},
+            {"ts": "2024-01-15T10:00:01Z", "type": "STEP_START", "step_id": "extract"},
+            {
+                "ts": "2024-01-15T10:00:05Z",
+                "type": "METRICS",
+                "step_id": "extract",
+                "metrics": {"rows_read": 1000},
+            },
+            {"ts": "2024-01-15T10:00:06Z", "type": "STEP_COMPLETE", "step_id": "extract"},
+            {"ts": "2024-01-15T10:05:00Z", "type": "COMPLETE", "total_rows": 1000},
+        ]
+        metrics = [{"step_id": "extract", "rows_read": 1000, "duration_ms": 6000}]
+        artifacts = []
+
+        e = build_evidence_layer(events, metrics, artifacts, max_bytes=300_000)
+
+        # Top-level keys
+        assert set(e.keys()) >= {"timeline", "metrics", "errors", "artifacts"}
+
+        # Timeline checks
+        assert len(e["timeline"]) == 5
+        timeline_types = [event["type"] for event in e["timeline"]]
+        assert timeline_types == ["START", "STEP_START", "METRICS", "STEP_COMPLETE", "COMPLETE"]
+
+        # Metrics checks
+        assert "steps" in e["metrics"]
+        assert e["metrics"]["steps"]["extract"]["rows_read"] == 1000
+        assert e["metrics"]["steps"]["extract"]["duration_ms"] == 6000
+
+        # All timeline events have correct @id format
+        for event in e["timeline"]:
+            assert "@id" in event
+            assert event["@id"].startswith("ev.event.")
+            # Check format: ev.event.<type>.<step_or_run>.<ts_ms>
+            parts = event["@id"].split(".")
+            assert len(parts) == 5  # ev, event, type, step_or_run, ts_ms
+            assert parts[0] == "ev"
+            assert parts[1] == "event"


### PR DESCRIPTION
## Summary

Implements PR2 of the M2a AIOP milestone - Evidence Layer functions with refined specification.

This PR adds the core evidence layer functionality that will be used by the full AIOP builder in later PRs.

## Changes

### New Files
- `osiris/core/run_export_v2.py` - Evidence layer implementation with 6 public functions
- `tests/core/test_run_export_v2.py` - Comprehensive tests including manual sanity checks

### Modified Files  
- `osiris/cli/logs.py` - CLI remains stub (prints "not implemented yet")
- `tests/cli/test_logs_aiop.py` - Tests verify stub behavior

## Implementation Details

### Evidence Layer Functions
1. **`build_evidence_layer`** - Main entry point, returns timeline/metrics/errors/artifacts
2. **`generate_evidence_id`** - Creates canonical IDs: `ev.<type>.<name>.<step_or_run>.<ts_ms>`
3. **`build_timeline`** - Chronological event list with density filtering (low/medium/high)
4. **`aggregate_metrics`** - Returns structured metrics with totals and per-step breakdowns
5. **`canonicalize_json`** - Deterministic JSON serialization with sorted keys
6. **`apply_truncation`** - Object-level truncation with proper markers

### Key Features
- ✅ Evidence ID format: `ev.event.<type_lc>.<step_or_run>.<ts_ms>`
- ✅ Timeline density filtering (low: major events, medium: +metrics, high: all)
- ✅ Metrics shape: `{total_rows, total_duration_ms, steps: {...}}`
- ✅ Object-level truncation markers
- ✅ CLI remains stub per PR2 specification
- ✅ Support for both `type` and `event` fields in event dictionaries
- ✅ Proper summing of duplicate metrics

## Test Coverage

13 tests covering:
- Evidence ID generation and sanitization
- Timeline chronological ordering and density filtering
- Metrics aggregation with topk selection
- JSON canonicalization
- Truncation with object-level markers
- Error extraction from events
- Artifact listing with SHA256 hashes
- Complete evidence layer structure validation

All tests passing: `13 passed in 0.58s`

## Validation

```bash
# Run PR2 tests
pytest tests/core/test_run_export_v2.py -q

# Verify CLI stub behavior
osiris logs aiop --last
# Output: "AIOP export not implemented yet (PR2)."
```

## Next Steps

- PR3: Narrative Layer (semantic interpretation)
- PR4: Export Formats (JSON + Markdown) 
- PR5: Full AIOP Builder wiring

🤖 Generated with [Claude Code](https://claude.ai/code)