### PR TITLE
fix: Update version to 0.3.0 and document branch protection rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,6 +352,14 @@ python osiris.py chat --pro-mode
    - All tests must pass
    - ADRs must be linked and referenced
 
+### Branch Protection Rules
+
+**⚠️ CRITICAL: The `main` branch is protected - NO direct commits allowed!**
+- All changes must go through pull requests
+- This includes version bumps, documentation updates, and all code changes
+- Only tags can be pushed directly: `git push origin v0.x.y`
+- If you accidentally commit locally to main, create a new branch from your changes
+
 ### Documentation & Decision Making
 
 #### Architecture Decision Records (ADRs)
@@ -427,18 +435,26 @@ python osiris.py chat --pro-mode
 **Branch**: feature/m2a-aiop-context (ready to merge to main)
 
 ### Release Process
+
+**⚠️ IMPORTANT: The `main` branch has protection rules - no direct commits allowed!**
+All changes to main MUST go through a pull request. This includes version bumps.
+
 1. **Complete milestone** in feature branch
-2. **Update version** in README.md and pyproject.toml
-3. **Update CHANGELOG.md** following [Keep a Changelog](https://keepachangelog.com) format
-4. **Create PR** to main with all changes
-5. **After merge**: Tag release (v0.x.y) and create GitHub Release
-6. **Document** release notes from CHANGELOG in GitHub Release
+2. **Update version** in pyproject.toml and CHANGELOG.md in feature branch
+3. **Create PR** to main with all changes (including version bump)
+4. **After PR merge**:
+   - Pull latest main
+   - Tag release (v0.x.y) locally
+   - Push tag only: `git push origin v0.x.y`
+5. **Create GitHub Release** from the pushed tag with changelog highlights
+
+**Note**: Never try to push commits directly to main - only tags can be pushed!
 
 ## Project Version
 
-**Current Version**: v0.3.0 (Released 2025-01-25)
+**Current Version**: v0.3.0 (Released 2025-09-27)
 **Status**: Production-ready with AIOP for LLM-friendly debugging
-**Branch**: feature/m2a-aiop-context
+**Branch**: main
 
 ## MVP Status
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "osiris-pipeline"
-version = "0.2.0"
+version = "0.3.0"
 description = "LLM-first conversational ETL pipeline generator"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## 🔧 Post-Release Version Bump and Documentation

This PR updates the version to 0.3.0 and documents critical branch protection rules discovered during the release process.

### Changes
- ✅ Bump version in `pyproject.toml` to 0.3.0 for M2a AIOP release
- ✅ Document branch protection rules in `CLAUDE.md`
- ✅ Fix release date to 2025-09-27
- ✅ Update release process documentation to reflect PR requirement

### Important Discovery
The `main` branch has protection rules that prevent direct commits. All changes must go through pull requests. This has been documented in CLAUDE.md to prevent future confusion.

### Context
This PR was created after successfully publishing the v0.3.0 release. The release tag and GitHub Release are already live at https://github.com/keboola/osiris/releases/tag/v0.3.0

### Test Plan
- [x] Version correctly updated in pyproject.toml
- [x] Documentation accurately reflects branch protection rules
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)