### PR TITLE
docs: Update README version to v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Osiris Pipeline v0.3.0
+# Osiris Pipeline v0.3.1
 
 **The deterministic compiler for AI-native data pipelines.**
 You describe outcomes in plain English; Osiris compiles them into **reproducible, production-ready manifests** that run with the **same behavior everywhere** (local or cloud).
@@ -133,7 +133,8 @@ For comprehensive documentation, visit the **[Documentation Hub](docs/README.md)
 ## 🚦 Roadmap
 
 - **v0.2.0** ✅ - Conversational agent, deterministic compiler, E2B parity
-- **v0.3.0 (Current)** ✅ - AI Operation Package (AIOP) for LLM-friendly debugging
+- **v0.3.0** ✅ - AI Operation Package (AIOP) for LLM-friendly debugging
+- **v0.3.1 (Current)** ✅ - Fixed validation warnings for ADR-0020 compliant configs
 - **M2** - Production workflows, approvals, orchestrator integration
 - **M3** - Streaming, parallelism, enterprise scale
 - **M4** - Iceberg tables, intelligent DWH agent


### PR DESCRIPTION
## Summary
Update README.md to reflect the current version v0.3.1 after the patch release.

## Changes
- Updated header from v0.3.0 to v0.3.1
- Added v0.3.1 to roadmap section as "(Current)"
- Marked v0.3.0 as previous version

## Context
Follow-up to PR #33 and the v0.3.1 release tag.

This is a documentation-only change with no code modifications.