### PR TITLE
chore: bump version to 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2025-10-07
+
 ### Added
 - **GraphQL Extractor Component** (`graphql.extractor`)
   - New driver: `osiris/drivers/graphql_extractor_driver.py` for GraphQL API data extraction

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Osiris Pipeline v0.3.1
+# Osiris Pipeline v0.3.5
 
 **The deterministic compiler for AI-native data pipelines.**
 You describe outcomes in plain English; Osiris compiles them into **reproducible, production-ready manifests** that run with the **same behavior everywhere** (local or cloud).
@@ -134,7 +134,8 @@ For comprehensive documentation, visit the **[Documentation Hub](docs/README.md)
 
 - **v0.2.0** ✅ - Conversational agent, deterministic compiler, E2B parity
 - **v0.3.0** ✅ - AI Operation Package (AIOP) for LLM-friendly debugging
-- **v0.3.1 (Current)** ✅ - Fixed validation warnings for ADR-0020 compliant configs
+- **v0.3.1** ✅ - Fixed validation warnings for ADR-0020 compliant configs
+- **v0.3.5 (Current)** ✅ - GraphQL extractor, DuckDB processor, test infrastructure improvements
 - **M2** - Production workflows, approvals, orchestrator integration
 - **M3** - Streaming, parallelism, enterprise scale
 - **M4** - Iceberg tables, intelligent DWH agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "osiris-pipeline"
-version = "0.3.1"
+version = "0.3.5"
 description = "LLM-first conversational ETL pipeline generator"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
- Updated version in pyproject.toml, README.md, and CHANGELOG.md
- Moved Unreleased changes to v0.3.5 (2025-10-07)
- Added v0.3.5 to roadmap with GraphQL extractor, DuckDB processor, and test improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)