### PR TITLE
fix(connectors/mysql): engine guards and safe doctor() connection args [draft]

### DIFF
--- a/osiris/connectors/mysql/client.py
+++ b/osiris/connectors/mysql/client.py
@@ -91,6 +91,8 @@ class MySQLClient:
             )
 
             # Test connection
+            if not self.engine:
+                raise RuntimeError("Engine not initialized")
             with self.engine.connect() as conn:
                 result = conn.execute(text("SELECT 1"))
                 result.fetchone()
@@ -125,6 +127,9 @@ class MySQLClient:
             if not self._initialized:
                 await self.connect()
 
+            if not self.engine:
+                return False
+
             with self.engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
                 return True
@@ -156,11 +161,11 @@ class MySQLClient:
             # Try to connect and execute a simple query
             conn = pymysql.connect(
                 host=connection.get("host", "localhost"),
-                port=connection.get("port", 3306),
-                user=connection.get("user"),
-                password=connection.get("password"),
-                database=connection.get("database"),
-                connect_timeout=timeout,
+                port=int(connection.get("port", 3306)),
+                user=connection.get("user") or "",
+                password=connection.get("password") or "",
+                database=connection.get("database") or "",
+                connect_timeout=int(timeout),
             )
 
             with conn.cursor() as cursor:


### PR DESCRIPTION
# fix(connectors/mysql): engine guards and safe doctor() connection args

## Summary
Added defensive programming improvements to the MySQL client:
- **Engine guards**: Added `None` checks before calling `self.engine.connect()` to prevent AttributeError
- **Type safety in doctor()**: Cast `port` and `connect_timeout` to `int()` and provide empty string fallbacks for optional connection parameters (`user`, `password`, `database`)

These changes address type checker warnings and make the client more robust against configuration edge cases.

## Review & Testing Checklist for Human
- [ ] **Test doctor() method with incomplete connection configs** - verify that empty string fallbacks for user/password/database don't cause unexpected MySQL connection errors
- [ ] **Test engine guard behavior** - ensure the new `None` checks don't break existing connection flows or change expected error handling
- [ ] **Verify int() casting** - test that port/timeout casting works with string inputs and doesn't fail unexpectedly

### Notes
- Changes are defensive programming focused on type safety and None-guard improvements
- The doctor() method changes are the highest risk since they modify connection parameter handling
- Could not test against live MySQL instance during development

Link to Devin run: https://app.devin.ai/sessions/d060f834dd584accae7754671cfc0385  
Requested by: @padak