### PR TITLE
fix: Release v0.5.3 - Python 3.11+ requirement + log_metric kwargs (fixes #51, #52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.5.3] - 2025-11-06
+
+**Bug Fixes - Python Version & Runtime**
+
+This release corrects Python version requirements and fixes a critical runtime bug preventing CSV extractor execution.
+
+### Fixed
+
+1. **Python Version Requirement (Issue #52)**
+   - Corrected `requires-python` from `>=3.9` to `>=3.11` in PyPI metadata
+   - Updated all documentation to reflect Python 3.11+ requirement
+   - Removed Python 3.9/3.10 classifiers, added Python 3.13
+   - Files updated: pyproject.toml, CLAUDE.md, docs/quickstart.md, docs/guides/mcp-production.md, e2e-test-simple.sh
+
+2. **RunnerContext.log_metric() Missing **kwargs (Issue #51)**
+   - Fixed signature mismatch causing TypeError when drivers use tags parameter
+   - Changed `def log_metric(self, name: str, value: Any):` to accept `**kwargs`
+   - CSV extractor and other components now execute without TypeError
+   - File: `osiris/core/runner_v0.py:448-449`
+
+### Impact
+
+- **Breaking**: Python 3.9 and 3.10 are no longer supported (use Python 3.11+)
+- **Fixed**: CSV extraction pipelines now work correctly with metric tags
+
 ## [0.5.2] - 2025-11-06
 
 **Critical Bug Fixes Batch 3 - Code Review Findings**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,9 +282,9 @@ osiris/
 ```
 
 ## Version Info
-- Current: v0.5.0 (Production Ready)
+- Current: v0.5.2 (Production Ready)
 - Model: Opus 4.1 (claude-opus-4-1-20250805)
-- Python: 3.8+ required
+- Python: 3.11+ required
 - Test Suite: ~196 seconds full run
 
 For detailed information, see documentation in `docs/`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Osiris Pipeline v0.5.2
+# Osiris Pipeline v0.5.3
 
 **The deterministic compiler for AI-native data pipelines.**
 You describe outcomes in plain English; Osiris compiles them into **reproducible, production-ready manifests** that run with the **same behavior everywhere** (local or cloud).
@@ -128,7 +128,7 @@ For comprehensive documentation, visit the **[Documentation Hub](docs/README.md)
 - **v0.3.0** ✅ - AI Operation Package (AIOP) for LLM-friendly debugging
 - **v0.3.1** ✅ - Fixed validation warnings for ADR-0020 compliant configs
 - **v0.3.5** ✅ - GraphQL extractor, DuckDB processor, test infrastructure improvements
-- **v0.5.2 (Current)** ✅ - Critical bug fixes batch 3: Path traversal (CWE-22), collision detection, OML schema, CSV extractor, Windows compatibility
+- **v0.5.3 (Current)** ✅ - Python version requirement fix + CSV extractor runtime bug fix
 - **M2** - Production workflows, approvals, orchestrator integration
 - **M3** - Streaming, parallelism, enterprise scale
 - **M4** - Iceberg tables, intelligent DWH agent

--- a/docs/guides/mcp-production.md
+++ b/docs/guides/mcp-production.md
@@ -28,7 +28,7 @@ Run these commands to verify production readiness:
 ```bash
 # 1. Verify Python environment
 python --version
-# Expected: Python 3.10+ (3.10, 3.11, 3.12 supported)
+# Expected: Python 3.11+ (3.11, 3.12, 3.13 supported)
 
 # 2. Activate virtual environment
 source .venv/bin/activate

--- a/docs/milestones/mcp-v0.5.0/attachments/e2e-test-simple.sh
+++ b/docs/milestones/mcp-v0.5.0/attachments/e2e-test-simple.sh
@@ -50,7 +50,7 @@ for arg in "$@"; do
             echo "Prerequisites:"
             echo "  • Virtual environment activated"
             echo "  • testing_env/ initialized with osiris.yaml"
-            echo "  • Python 3.9+ installed"
+            echo "  • Python 3.11+ installed"
             echo ""
             exit 0
             ;;

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,12 +1,12 @@
-# Osiris Pipeline v0.2.0 — Quick Start
+# Osiris Pipeline v0.5.2 — Quick Start
 
-A 10‑minute happy‑path to run your first pipeline locally and (optionally) in an E2B sandbox. We’ll move a small table from MySQL to a CSV file.
+A 10‑minute happy‑path to run your first pipeline locally and (optionally) in an E2B sandbox. We'll move a small table from MySQL to a CSV file.
 
 ---
 
 ## 1) Prerequisites
 
-- **Python 3.10+**
+- **Python 3.11+**
 - **Git**
 - **MySQL** database you can read from (host/user/password)
 - (Optional) **E2B** account if you want to try cloud sandbox runs

--- a/osiris/__init__.py
+++ b/osiris/__init__.py
@@ -14,7 +14,7 @@
 
 """Osiris MVP - Conversational ETL pipeline generator."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 __author__ = "Osiris Team"
 __description__ = "LLM-first conversational ETL pipeline generator"
 

--- a/osiris/core/runner_v0.py
+++ b/osiris/core/runner_v0.py
@@ -442,8 +442,8 @@ class RunnerV0:
                 def __init__(self, output_dir):
                     self.output_dir = output_dir
 
-                def log_metric(self, name: str, value: Any):
-                    log_metric(name, value)
+                def log_metric(self, name: str, value: Any, **kwargs):
+                    log_metric(name, value, **kwargs)
 
             ctx = RunnerContext(output_dir)
 

--- a/osiris/mcp/config.py
+++ b/osiris/mcp/config.py
@@ -106,7 +106,7 @@ class MCPConfig:
 
     # Protocol configuration
     PROTOCOL_VERSION = "2024-11-05"  # MCP protocol spec version
-    SERVER_VERSION = "0.5.2"  # Osiris server version
+    SERVER_VERSION = "0.5.3"  # Osiris server version
     SERVER_NAME = "osiris-mcp-server"
 
     # Payload limits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "osiris-pipeline"
-version = "0.5.2"
+version = "0.5.3"
 description = "LLM-first conversational ETL pipeline generator"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -26,17 +26,16 @@ classifiers = [
     "Environment :: Console",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
     "Topic :: Database",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = [
     "rich>=13.0.0",
     "pyyaml>=6.0.2",

--- a/tests/mcp/test_server_boot.py
+++ b/tests/mcp/test_server_boot.py
@@ -110,5 +110,5 @@ class TestServerBoot:
         from osiris.mcp.config import MCPConfig
 
         config = MCPConfig()
-        assert config.SERVER_VERSION == "0.5.2"
+        assert config.SERVER_VERSION == "0.5.3"
         assert config.PROTOCOL_VERSION == "2024-11-05"  # MCP protocol spec version


### PR DESCRIPTION
## Summary

Release **v0.5.3** fixes two critical issues reported by users:
- **Issue #52**: Incorrect Python version requirement (3.9 → 3.11)
- **Issue #51**: CSV extractor runtime crash due to missing **kwargs in log_metric()

## Changes

### Issue #52 - Python Version Requirement ✅

**Problem**: PyPI metadata claimed Python 3.9+ support, but Osiris actually requires Python 3.11+

**Fixed**:
- `pyproject.toml`: `requires-python = ">=3.11"` (was `>=3.9`)
- Removed Python 3.9/3.10 classifiers, added Python 3.13
- Updated all documentation:
  - `CLAUDE.md`: Python 3.11+ required
  - `docs/quickstart.md`: Python 3.11+ prerequisite
  - `docs/guides/mcp-production.md`: Python 3.11+ (3.11, 3.12, 3.13 supported)
  - `docs/milestones/mcp-v0.5.0/attachments/e2e-test-simple.sh`: Python 3.11+ check

**Impact**: 🔴 **Breaking** - Python 3.9 and 3.10 are no longer supported

---

### Issue #51 - RunnerContext.log_metric() Bug ✅

**Problem**: CSV extractor crashed with `TypeError: log_metric() got an unexpected keyword argument 'tags'`

**Root Cause**: `RunnerContext.log_metric()` wrapper didn't forward **kwargs to underlying function

**Fixed**:
```python
# File: osiris/core/runner_v0.py:445-446
# Before:
def log_metric(self, name: str, value: Any):
    log_metric(name, value)

# After:
def log_metric(self, name: str, value: Any, **kwargs):
    log_metric(name, value, **kwargs)
```

**Impact**: ✅ CSV extractor and other components now execute correctly with metric tags

---

## Version Updates

All version strings updated to **0.5.3**:
- ✅ `pyproject.toml` (PyPI metadata)
- ✅ `osiris/__init__.py` (__version__)
- ✅ `osiris/mcp/config.py` (SERVER_VERSION)
- ✅ `tests/mcp/test_server_boot.py` (test assertion)
- ✅ `README.md` (header + roadmap)
- ✅ `CHANGELOG.md` (comprehensive release notes)

## Testing

- ✅ Version test passes: `pytest tests/mcp/test_server_boot.py::TestServerBoot::test_server_version`
- ✅ CSV extractor now works with tags parameter
- ✅ Python 3.11+ requirement enforced in PyPI metadata

## Files Changed (11 files)

```
CHANGELOG.md
CLAUDE.md
README.md
docs/guides/mcp-production.md
docs/milestones/mcp-v0.5.0/attachments/e2e-test-simple.sh
docs/quickstart.md
osiris/__init__.py
osiris/core/runner_v0.py
osiris/mcp/config.py
pyproject.toml
tests/mcp/test_server_boot.py
```

## Release Checklist

- [x] Both issues fixed (#51, #52)
- [x] Version bumped to 0.5.3
- [x] CHANGELOG updated
- [x] All documentation updated
- [ ] PR merged to main
- [ ] PyPI package published
- [ ] GitHub release created
- [ ] Issues #51 and #52 closed

## Related Issues

Fixes #51 - RunnerContext.log_metric() missing **kwargs parameter causes execution failure
Fixes #52 - Python version requirement mismatch (pyproject.toml says 3.9+, but requires 3.11+)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
