### PR TITLE
hotfix: Release v0.5.4 - CLI version display fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.5.4] - 2025-11-06
+
+**Hotfix - CLI Version Display**
+
+This hotfix corrects the CLI version display which was hardcoded instead of reading from the package version.
+
+### Fixed
+
+1. **Hardcoded Version in CLI** (`osiris/cli/main.py:183-185`)
+   - Fixed `osiris --version` showing hardcoded "v0.5.0" instead of actual package version
+   - Changed from `print("Osiris v0.5.0")` to reading from `osiris.__version__`
+   - Both JSON and text output now correctly display current version
+   - File: `osiris/cli/main.py` lines 182-187
+
+### Impact
+
+- **Fixed**: `osiris --version` now correctly shows v0.5.4 (was showing v0.5.0 regardless of installed version)
+- Users can now reliably verify their installed Osiris version
+
 ## [0.5.3] - 2025-11-06
 
 **Bug Fixes - Python Version & Runtime**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Osiris Pipeline v0.5.3
+# Osiris Pipeline v0.5.4
 
 **The deterministic compiler for AI-native data pipelines.**
 You describe outcomes in plain English; Osiris compiles them into **reproducible, production-ready manifests** that run with the **same behavior everywhere** (local or cloud).
@@ -128,7 +128,8 @@ For comprehensive documentation, visit the **[Documentation Hub](docs/README.md)
 - **v0.3.0** ✅ - AI Operation Package (AIOP) for LLM-friendly debugging
 - **v0.3.1** ✅ - Fixed validation warnings for ADR-0020 compliant configs
 - **v0.3.5** ✅ - GraphQL extractor, DuckDB processor, test infrastructure improvements
-- **v0.5.3 (Current)** ✅ - Python version requirement fix + CSV extractor runtime bug fix
+- **v0.5.4 (Current)** ✅ - CLI version display hotfix
+- **v0.5.3** ✅ - Python version requirement fix + CSV extractor runtime bug fix
 - **M2** - Production workflows, approvals, orchestrator integration
 - **M3** - Streaming, parallelism, enterprise scale
 - **M4** - Iceberg tables, intelligent DWH agent

--- a/osiris/__init__.py
+++ b/osiris/__init__.py
@@ -14,7 +14,7 @@
 
 """Osiris MVP - Conversational ETL pipeline generator."""
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 __author__ = "Osiris Team"
 __description__ = "LLM-first conversational ETL pipeline generator"
 

--- a/osiris/cli/main.py
+++ b/osiris/cli/main.py
@@ -179,10 +179,11 @@ def main():
         logging.getLogger().setLevel(logging.DEBUG)
 
     if args.version:
+        from osiris import __version__
         if json_output:
-            print(json.dumps({"version": "v0.5.0"}))
+            print(json.dumps({"version": f"v{__version__}"}))
         else:
-            console.print("Osiris v0.5.0")
+            console.print(f"Osiris v{__version__}")
         return
 
     # Handle commands first, then help

--- a/osiris/mcp/config.py
+++ b/osiris/mcp/config.py
@@ -106,7 +106,7 @@ class MCPConfig:
 
     # Protocol configuration
     PROTOCOL_VERSION = "2024-11-05"  # MCP protocol spec version
-    SERVER_VERSION = "0.5.3"  # Osiris server version
+    SERVER_VERSION = "0.5.4"  # Osiris server version
     SERVER_NAME = "osiris-mcp-server"
 
     # Payload limits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "osiris-pipeline"
-version = "0.5.3"
+version = "0.5.4"
 description = "LLM-first conversational ETL pipeline generator"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/mcp/test_server_boot.py
+++ b/tests/mcp/test_server_boot.py
@@ -110,5 +110,5 @@ class TestServerBoot:
         from osiris.mcp.config import MCPConfig
 
         config = MCPConfig()
-        assert config.SERVER_VERSION == "0.5.3"
+        assert config.SERVER_VERSION == "0.5.4"
         assert config.PROTOCOL_VERSION == "2024-11-05"  # MCP protocol spec version


### PR DESCRIPTION
## Summary

Hotfix release **v0.5.4** fixes hardcoded version string in CLI that was showing "v0.5.0" regardless of installed package version.

## Problem

The `osiris --version` command was displaying hardcoded "v0.5.0" instead of reading from the actual package version.

**Root Cause**: Lines 183-185 in `osiris/cli/main.py` had hardcoded strings:
```python
print(json.dumps({"version": "v0.5.0"}))
console.print("Osiris v0.5.0")
```

## Fix

Updated `osiris/cli/main.py` to dynamically read version from package:

```python
from osiris import __version__
if json_output:
    print(json.dumps({"version": f"v{__version__}"}))
else:
    console.print(f"Osiris v{__version__}")
```

**Changed Lines**: `osiris/cli/main.py:182-187`

## Testing

✅ Before fix:
```bash
pip show osiris-pipeline | grep Version  # Version: 0.5.3
osiris --version                         # Osiris v0.5.0  ❌
```

✅ After fix:
```bash
pip show osiris-pipeline | grep Version  # Version: 0.5.4
osiris --version                         # Osiris v0.5.4  ✅
```

## Impact

- **Fixed**: `osiris --version` now correctly displays actual installed version
- **Applies to**: Both text output and JSON output (`--json --version`)
- **Users can now**: Reliably verify their installed Osiris version

## Version Updates

All version strings updated to **0.5.4**:
- ✅ `pyproject.toml` (PyPI metadata)
- ✅ `osiris/__init__.py` (__version__)
- ✅ `osiris/mcp/config.py` (SERVER_VERSION)
- ✅ `tests/mcp/test_server_boot.py` (test assertion)
- ✅ `README.md` (header + roadmap)
- ✅ `CHANGELOG.md` (hotfix entry)

## Files Changed (7 files)

```
CHANGELOG.md
README.md
osiris/__init__.py
osiris/cli/main.py
osiris/mcp/config.py
pyproject.toml
tests/mcp/test_server_boot.py
```

## Release Checklist

- [x] Bug fixed (hardcoded version)
- [x] Version bumped to 0.5.4
- [x] CHANGELOG updated
- [x] All version references updated
- [ ] PR merged to main
- [ ] Git tag created
- [ ] GitHub release created
- [ ] PyPI package published

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
