### PR TITLE
fix: Correct capabilities format in component developer skill

### DIFF
--- a/.claude/skills/osiris-component-developer/CHECKLIST.md
+++ b/.claude/skills/osiris-component-developer/CHECKLIST.md
@@ -17,10 +17,10 @@ All Osiris components must pass these 57 validation rules before distribution.
 
 ## CAPABILITIES (4 rules)
 
-- [ ] **CAP-001**: Declares `capabilities` array
-- [ ] **CAP-002**: Has `discover` capability if mode includes `discover`
-- [ ] **CAP-003**: Has `healthcheck` capability (recommended for all components)
-- [ ] **CAP-004**: All declared capabilities are actually implemented in driver
+- [ ] **CAP-001**: Declares `capabilities` object (not array) with boolean flags
+- [ ] **CAP-002**: Sets `discover: true` if mode includes `discover`
+- [ ] **CAP-003**: Declares all 8 standard capabilities (discover, adHocAnalytics, inMemoryMove, streaming, bulkOperations, transactions, partitioning, customTransforms)
+- [ ] **CAP-004**: All capabilities set to `true` are actually implemented in driver
 
 ## DISCOVERY (6 rules)
 

--- a/.claude/skills/osiris-component-developer/POSTHOG_EXAMPLE.md
+++ b/.claude/skills/osiris-component-developer/POSTHOG_EXAMPLE.md
@@ -91,10 +91,14 @@ modes:
   - discover
 
 capabilities:
-  - discover
-  - healthcheck
-  - pagination
-  - filtering
+  discover: true            # Supports discovery mode
+  adHocAnalytics: false     # No ad-hoc query support
+  inMemoryMove: false       # Returns DataFrame but no direct move API
+  streaming: false          # Batch processing only
+  bulkOperations: true      # Supports pagination for large datasets
+  transactions: false       # REST API doesn't support transactions
+  partitioning: false       # No partitioning support
+  customTransforms: false   # No custom transforms
 
 configSchema:
   type: object

--- a/.claude/skills/osiris-component-developer/SKILL.md
+++ b/.claude/skills/osiris-component-developer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: osiris-component-developer
-description: Create production-ready Osiris ETL components (extractors, writers, processors). Use when building new components, implementing discovery/doctor capabilities, packaging for distribution, validating against 57-rule checklist, or ensuring E2B cloud compatibility. Supports third-party component development in isolated projects.
+description: Create production-ready Osiris ETL components (extractors, writers, processors). Use when building new components, implementing capabilities (discover, streaming, bulkOperations), adding doctor/healthcheck methods, packaging for distribution, validating against 57-rule checklist, or ensuring E2B cloud compatibility. Supports third-party component development in isolated projects.
 ---
 
 # Osiris Component Developer
@@ -23,7 +23,7 @@ You are an AI assistant specialized in developing components for the Osiris LLM-
 - **Component (spec.yaml)**: Self-describing declarative specification
 - **Driver**: Python implementation of operations
 - **Registry**: Validates and serves component metadata
-- **Capabilities**: Discovery, doctor, bulkOperations, transactions
+- **Capabilities**: discover, adHocAnalytics, inMemoryMove, streaming, bulkOperations, transactions, partitioning, customTransforms (all boolean flags)
 - **Modes**: extract, write, transform, discover
 
 ### Required Files Structure
@@ -77,8 +77,14 @@ modes:
   - extract  # or write, transform, discover
 
 capabilities:
-  - discover
-  - healthcheck
+  discover: true            # Supports schema/metadata discovery
+  adHocAnalytics: false     # Supports ad-hoc analytical queries
+  inMemoryMove: false       # Supports in-memory data movement
+  streaming: false          # Supports streaming/incremental processing
+  bulkOperations: true      # Supports bulk insert/update operations
+  transactions: false       # Supports transactional operations
+  partitioning: false       # Supports partitioned processing
+  customTransforms: false   # Supports custom transformation logic
 
 configSchema:
   type: object
@@ -152,7 +158,7 @@ class ProviderComponentDriver:
             pass
 
     def discover(self, connection: dict, timeout: float = 10.0) -> dict:
-        """Discover available resources (if capability: discover)."""
+        """Discover available resources (if capabilities.discover: true)."""
         import hashlib
         import json
         from datetime import datetime
@@ -174,7 +180,7 @@ class ProviderComponentDriver:
         }
 
     def doctor(self, connection: dict, timeout: float = 2.0) -> tuple[bool, dict]:
-        """Health check (if capability: healthcheck)."""
+        """Health check for connection (optional method for connection testing)."""
         import time
 
         start = time.time()

--- a/.claude/skills/osiris-component-developer/TEMPLATES.md
+++ b/.claude/skills/osiris-component-developer/TEMPLATES.md
@@ -15,8 +15,14 @@ modes:
   - extract  # or: write, transform, discover
 
 capabilities:
-  - discover
-  - healthcheck
+  discover: true
+  adHocAnalytics: false
+  inMemoryMove: false
+  streaming: false
+  bulkOperations: true
+  transactions: false
+  partitioning: false
+  customTransforms: false
 
 configSchema:
   type: object


### PR DESCRIPTION
## Problem (Critical Bug)

The osiris-component-developer skill was teaching **incorrect capabilities format** that would cause validation failures.

### What Was Wrong ❌

```yaml
# Skill taught THIS (incorrect):
capabilities:
  - discover
  - healthcheck    # doesn't exist!
  - bulkOperations
```

**Issues:**
1. Capabilities as **array** instead of object
2. Referenced non-existent `"healthcheck"` capability
3. Components following skill would **fail validation**

### What's Correct ✅

According to `components/spec.schema.json`:

```yaml
# Must be object with boolean flags:
capabilities:
  discover: true            # Supports schema/metadata discovery
  adHocAnalytics: false     # Supports ad-hoc analytical queries
  inMemoryMove: false       # Supports in-memory data movement
  streaming: false          # Supports streaming/incremental processing
  bulkOperations: true      # Supports bulk insert/update operations
  transactions: false       # Supports transactional operations
  partitioning: false       # Supports partitioned processing
  customTransforms: false   # Supports custom transformation logic
```

**8 standard capabilities** (per spec.schema.json):
- `discover`, `adHocAnalytics`, `inMemoryMove`, `streaming`
- `bulkOperations`, `transactions`, `partitioning`, `customTransforms`

**Note**: No `"healthcheck"` or `"doctor"` capability exists. `doctor()` is a driver **method**, not a capability.

## Changes

Fixed in 4 files:

1. **SKILL.md**:
   - Fixed spec.yaml template with correct object format
   - Updated frontmatter description
   - Fixed docstrings for `discover()` and `doctor()` methods

2. **CHECKLIST.md**:
   - Updated CAP-001: "Declares capabilities object (not array)"
   - Updated CAP-002: "Sets discover: true if mode includes discover"
   - Updated CAP-003: Lists all 8 standard capabilities
   - Updated CAP-004: Clarifies only `true` capabilities need implementation

3. **POSTHOG_EXAMPLE.md**:
   - Fixed example spec.yaml to use object format
   - Added all 8 standard capabilities with comments

4. **TEMPLATES.md**:
   - Fixed minimal spec.yaml template with correct format

## Validation

✅ Checked against actual component specs:
- `components/mysql.extractor/spec.yaml`
- `components/supabase.extractor/spec.yaml`
- `components/filesystem.csv_extractor/spec.yaml`

✅ Confirmed against `components/spec.schema.json`

✅ Reference docs (`docs/reference/COMPONENT_CAPABILITIES_*.md`) already correct

## Credit

Issue discovered by **Codex CLI review**. Thanks to OpenAI model for catching this critical bug! 🙏

## Impact

- **Before**: Following skill would create invalid specs → validation failure
- **After**: Skill teaches correct format → components validate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)